### PR TITLE
Add OPUS design system theme with colors, typography, and spacing

### DIFF
--- a/lib/core/theme/opus_colors.dart
+++ b/lib/core/theme/opus_colors.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+/// Couleurs OPUS Mobile - "Béton & Latérite"
+///
+/// Cette classe centralise TOUTES les couleurs de l'app.
+/// Ne pas créer de couleurs custom ailleurs.
+///
+/// Référence: design/OPUS_Charte_Graphique_Final_v3.md
+class OpusColors {
+  OpusColors._(); // Private constructor - classe utilitaire
+
+  // ============================================================================
+  // COULEURS PRIMAIRES
+  // ============================================================================
+
+  /// 🪧 Rouge Enseigne - Couleur signature OPUS
+  /// Usage: CTAs principaux, actions urgentes, badges importants
+  /// Inspiration: Enseignes peintes à la main des boutiques informelles
+  static const Color rougeEnseigne = Color(0xFFE63946);
+
+  /// 🛖 Indigo Bâche - Structure
+  /// Usage: Headers, navigation, éléments structurels
+  /// Inspiration: Bâches bleues délavées des marchés
+  static const Color indigoBache = Color(0xFF1D3557);
+
+  /// 🚕 Jaune Taxi - Opportunité
+  /// Usage: Badges "Nouveau", highlights, pricing
+  /// Inspiration: Taxis wôrô-wôrô jaune-orange
+  static const Color jauneTaxi = Color(0xFFF4A261);
+
+  /// 🏜️ Ocre Latérite - Chaleur
+  /// Usage: Accents secondaires, illustrations, éléments chaleureux
+  /// Inspiration: Terre rouge des rues non-pavées
+  static const Color ocreLaterite = Color(0xFFE76F51);
+
+  // ============================================================================
+  // COULEURS SECONDAIRES
+  // ============================================================================
+
+  static const Color betonBrut = Color(0xFF6C757D);
+  static const Color grisAsphalte = Color(0xFF495057);
+  static const Color bleuBache = Color(0xFF457B9D);
+  static const Color terreRouge = Color(0xFFA8402F);
+
+  // ============================================================================
+  // COULEURS NEUTRES
+  // ============================================================================
+
+  static const Color noirGoudron = Color(0xFF212529);
+  static const Color grisMur = Color(0xFF343A40);
+  static const Color grisPoussiere = Color(0xFFADB5BD);
+  static const Color blancChaux = Color(0xFFF8F9FA);
+  static const Color blancPur = Color(0xFFFFFFFF);
+
+  // ============================================================================
+  // COULEURS SÉMANTIQUES
+  // ============================================================================
+
+  static const Color success = Color(0xFF10B981);
+  static const Color warning = Color(0xFFF4A261); // Utilise Jaune Taxi
+  static const Color error = Color(0xFFEF4444);
+  static const Color info = Color(0xFF457B9D); // Utilise Bleu Bâche
+
+  // ============================================================================
+  // DÉGRADÉS
+  // ============================================================================
+
+  /// Gradient Rouge Enseigne (pour CTAs principaux)
+  static const LinearGradient enseigneGradient = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [rougeEnseigne, terreRouge],
+  );
+
+  /// Gradient Indigo (pour headers, navigation)
+  static const LinearGradient nuitGradient = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [indigoBache, bleuBache],
+  );
+
+  /// Gradient Jaune-Ocre (pour badges premium)
+  static const LinearGradient soleilGradient = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [jauneTaxi, ocreLaterite],
+  );
+
+  /// Gradient Béton (pour backgrounds sombres)
+  static const LinearGradient betonGradient = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [grisAsphalte, noirGoudron],
+  );
+}

--- a/lib/core/theme/opus_spacing.dart
+++ b/lib/core/theme/opus_spacing.dart
@@ -1,0 +1,18 @@
+/// Système de spacing OPUS - Multiples de 4px
+///
+/// RÈGLE: TOUS les spacing/padding/margin DOIVENT être multiples de 4.
+///
+/// Référence: design/OPUS_Charte_Graphique_Final_v3.md
+class OpusSpacing {
+  OpusSpacing._();
+
+  static const double xs = 4.0;
+  static const double sm = 8.0;
+  static const double md = 12.0;
+  static const double lg = 16.0;   // Default
+  static const double xl = 20.0;
+  static const double xxl = 24.0;
+  static const double xxxl = 32.0;
+  static const double xxxxl = 40.0;
+  static const double xxxxxl = 48.0;
+}

--- a/lib/core/theme/opus_text_styles.dart
+++ b/lib/core/theme/opus_text_styles.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'opus_colors.dart';
+
+/// Styles de texte OPUS - Police Inter
+///
+/// Hiérarchie typographique basée sur la charte graphique.
+/// Police: Inter (Google Fonts)
+///
+/// Référence: design/OPUS_Charte_Graphique_Final_v3.md
+class OpusTextStyles {
+  OpusTextStyles._();
+
+  // ============================================================================
+  // TITRES
+  // ============================================================================
+
+  /// H1 - Titres de pages
+  static const TextStyle h1 = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 32,
+    fontWeight: FontWeight.w800, // ExtraBold
+    height: 1.2,
+    letterSpacing: -0.5,
+    color: OpusColors.noirGoudron,
+  );
+
+  /// H2 - Titres de sections
+  static const TextStyle h2 = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 19,
+    fontWeight: FontWeight.w800,
+    height: 1.26,
+    letterSpacing: -0.3,
+    color: OpusColors.noirGoudron,
+  );
+
+  /// H3 - Titres de cards
+  static const TextStyle h3 = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 17,
+    fontWeight: FontWeight.w700, // Bold
+    height: 1.3,
+    color: OpusColors.noirGoudron,
+  );
+
+  // ============================================================================
+  // BODY
+  // ============================================================================
+
+  /// Body Regular - Texte principal
+  static const TextStyle bodyRegular = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 16,
+    fontWeight: FontWeight.w500, // Medium
+    height: 1.5,
+    color: OpusColors.grisMur,
+  );
+
+  /// Body Small - Texte secondaire
+  static const TextStyle bodySmall = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 1.43,
+    color: OpusColors.grisAsphalte,
+  );
+
+  /// Caption - Labels, timestamps
+  static const TextStyle caption = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: FontWeight.w600, // SemiBold
+    height: 1.33,
+    letterSpacing: 0.5,
+    color: OpusColors.betonBrut,
+  );
+
+  /// Caption Uppercase - Metadata, badges
+  static const TextStyle captionUppercase = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 11,
+    fontWeight: FontWeight.w700,
+    height: 1.45,
+    letterSpacing: 0.5,
+    color: OpusColors.betonBrut,
+  );
+
+  // ============================================================================
+  // BOUTONS
+  // ============================================================================
+
+  /// Button Text - Texte des boutons
+  static const TextStyle button = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 18,
+    fontWeight: FontWeight.w800,
+    letterSpacing: -0.3,
+    color: OpusColors.blancPur,
+  );
+
+  /// Button Small - Petits boutons
+  static const TextStyle buttonSmall = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    letterSpacing: -0.2,
+    color: OpusColors.blancPur,
+  );
+}

--- a/lib/core/theme/opus_theme.dart
+++ b/lib/core/theme/opus_theme.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'opus_colors.dart';
+import 'opus_text_styles.dart';
+
+/// Theme OPUS Mobile complet
+///
+/// Applique la charte graphique "Béton & Latérite" à toute l'app.
+class OpusTheme {
+  OpusTheme._();
+
+  static ThemeData get lightTheme {
+    return ThemeData(
+      useMaterial3: true,
+
+      // Couleurs
+      colorScheme: ColorScheme.light(
+        primary: OpusColors.rougeEnseigne,
+        secondary: OpusColors.indigoBache,
+        tertiary: OpusColors.jauneTaxi,
+        error: OpusColors.error,
+        surface: OpusColors.blancChaux,
+        onPrimary: OpusColors.blancPur,
+        onSecondary: OpusColors.blancPur,
+        onSurface: OpusColors.noirGoudron,
+      ),
+
+      // Scaffold
+      scaffoldBackgroundColor: OpusColors.blancChaux,
+
+      // AppBar
+      appBarTheme: AppBarTheme(
+        backgroundColor: OpusColors.indigoBache,
+        foregroundColor: OpusColors.blancPur,
+        elevation: 0,
+        centerTitle: false,
+        titleTextStyle: OpusTextStyles.h2.copyWith(
+          color: OpusColors.blancPur,
+        ),
+      ),
+
+      // Textes
+      textTheme: TextTheme(
+        displayLarge: OpusTextStyles.h1,
+        displayMedium: OpusTextStyles.h2,
+        displaySmall: OpusTextStyles.h3,
+        bodyLarge: OpusTextStyles.bodyRegular,
+        bodyMedium: OpusTextStyles.bodySmall,
+        labelSmall: OpusTextStyles.caption,
+      ),
+
+      // Boutons
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: OpusColors.rougeEnseigne,
+          foregroundColor: OpusColors.blancPur,
+          textStyle: OpusTextStyles.button,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          elevation: 8,
+          shadowColor: OpusColors.rougeEnseigne.withOpacity(0.3),
+        ),
+      ),
+
+      // Cards
+      cardTheme: CardTheme(
+        color: OpusColors.blancPur,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: OpusColors.blancChaux, width: 2),
+        ),
+        margin: const EdgeInsets.all(0),
+      ),
+
+      // Input
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: OpusColors.blancChaux,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: OpusColors.blancChaux, width: 2),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: OpusColors.blancChaux, width: 2),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: OpusColors.rougeEnseigne, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: OpusColors.error, width: 2),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -1,0 +1,7 @@
+/// Export de tous les fichiers theme OPUS
+library opus_theme;
+
+export 'opus_colors.dart';
+export 'opus_spacing.dart';
+export 'opus_text_styles.dart';
+export 'opus_theme.dart';


### PR DESCRIPTION
## Summary
Implement a comprehensive design system for the OPUS mobile app based on the "Béton & Latérite" visual identity. This establishes a centralized, consistent theming system across the entire application.

## Key Changes
- **OpusColors** - Centralized color palette with:
  - Primary colors (Rouge Enseigne, Indigo Bâche, Jaune Taxi, Ocre Latérite)
  - Secondary and neutral colors
  - Semantic colors (success, warning, error, info)
  - Pre-defined gradients for common UI patterns

- **OpusTextStyles** - Complete typographic hierarchy using Inter font:
  - Heading styles (H1, H2, H3) for page and section titles
  - Body text styles (Regular, Small) for content
  - Caption styles for labels and metadata
  - Button text styles (standard and small)

- **OpusSpacing** - Consistent spacing system based on 4px multiples:
  - 8 spacing constants (xs to xxxxxl) for padding, margins, and gaps
  - Enforces visual consistency across layouts

- **OpusTheme** - Complete Material 3 theme configuration:
  - Color scheme mapping to primary, secondary, and tertiary colors
  - AppBar styling with Indigo Bâche background
  - Elevated button styling with Rouge Enseigne and shadow effects
  - Card and input field theming with rounded corners (14-16px radius)
  - Consistent elevation and spacing throughout

- **theme.dart** - Barrel export file for easy imports across the codebase

## Implementation Details
- All colors reference the design specification (OPUS_Charte_Graphique_Final_v3.md)
- Color names use evocative French names tied to the visual identity (e.g., "rougeEnseigne" for shop sign red)
- Text styles include proper line heights and letter spacing for visual hierarchy
- Theme uses Material 3 with custom styling for buttons, cards, and inputs
- Spacing system enforces 4px grid alignment for pixel-perfect layouts

https://claude.ai/code/session_01K95rJLS9pWgxHR3uebajZm