### PR TITLE
feat: sélecteur de pays Canada (+1) pour les tests

### DIFF
--- a/lib/features/auth/screens/phone_registration_screen.dart
+++ b/lib/features/auth/screens/phone_registration_screen.dart
@@ -15,8 +15,15 @@ class PhoneRegistrationScreen extends StatefulWidget {
       _PhoneRegistrationScreenState();
 }
 
+typedef _Country = ({String code, String flag, String hint});
+
 class _PhoneRegistrationScreenState extends State<PhoneRegistrationScreen> {
-  static const String _countryCode = '+225';
+  static const List<_Country> _countries = [
+    (code: '+225', flag: '🇨🇮', hint: 'XX XX XX XX XX'),
+    (code: '+1', flag: '🇨🇦', hint: 'XXX XXX XXXX'),
+  ];
+
+  _Country _selected = _countries.first;
 
   final _formKey = GlobalKey<FormState>();
   final _phoneController = TextEditingController();
@@ -32,7 +39,7 @@ class _PhoneRegistrationScreenState extends State<PhoneRegistrationScreen> {
     super.dispose();
   }
 
-  String get _fullPhone => '$_countryCode${_phoneController.text.trim()}';
+  String get _fullPhone => '${_selected.code}${_phoneController.text.trim()}';
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
@@ -117,11 +124,11 @@ class _PhoneRegistrationScreenState extends State<PhoneRegistrationScreen> {
                   Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // Country code prefix chip (non-editable)
+                      // Country code selector
                       Container(
                         height: 56,
                         padding: const EdgeInsets.symmetric(
-                          horizontal: OpusSpacing.md,
+                          horizontal: OpusSpacing.sm,
                         ),
                         decoration: BoxDecoration(
                           color: OpusColors.indigoBache.withValues(alpha: 0.08),
@@ -130,22 +137,42 @@ class _PhoneRegistrationScreenState extends State<PhoneRegistrationScreen> {
                           ),
                           borderRadius: BorderRadius.circular(OpusSpacing.sm),
                         ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              '🇨🇮',
-                              style: const TextStyle(fontSize: 20),
-                            ),
-                            const SizedBox(width: OpusSpacing.xs),
-                            Text(
-                              _countryCode,
-                              style: OpusTextStyles.body.copyWith(
-                                color: OpusColors.indigoBache,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                          ],
+                        child: DropdownButtonHideUnderline(
+                          child: DropdownButton<_Country>(
+                            value: _selected,
+                            isDense: false,
+                            icon: const Icon(Icons.arrow_drop_down, size: 18),
+                            iconEnabledColor: OpusColors.indigoBache,
+                            onChanged: (country) {
+                              if (country != null) {
+                                setState(() {
+                                  _selected = country;
+                                  _phoneController.clear();
+                                });
+                              }
+                            },
+                            items: _countries
+                                .map(
+                                  (c) => DropdownMenuItem(
+                                    value: c,
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Text(c.flag, style: const TextStyle(fontSize: 20)),
+                                        const SizedBox(width: OpusSpacing.xs),
+                                        Text(
+                                          c.code,
+                                          style: OpusTextStyles.body.copyWith(
+                                            color: OpusColors.indigoBache,
+                                            fontWeight: FontWeight.w700,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
                         ),
                       ),
                       const SizedBox(width: OpusSpacing.sm),
@@ -165,7 +192,7 @@ class _PhoneRegistrationScreenState extends State<PhoneRegistrationScreen> {
                             color: OpusColors.noirGoudron,
                           ),
                           decoration: InputDecoration(
-                            hintText: 'XX XX XX XX XX',
+                            hintText: _selected.hint,
                             hintStyle: OpusTextStyles.body.copyWith(
                               color: OpusColors.grisPoussiere,
                             ),


### PR DESCRIPTION
## Résumé

- Remplace le chip statique `🇨🇮 +225` par un `DropdownButton` permettant de choisir entre **+225 (Côte d'Ivoire)** et **+1 (Canada)**
- Le placeholder du champ de saisie s'adapte au pays sélectionné (`XXX XXX XXXX` pour le Canada)
- Le champ se vide automatiquement lors d'un changement de pays

## Motivation

Faciliter les tests en développement avec des numéros de téléphone canadiens, sans impacter la logique de validation (10 chiffres dans les deux cas).

## À noter pour le reviewer

- Aucun changement backend — le numéro complet est toujours envoyé au format E.164 (`+<code><10 chiffres>`)
- Changement purement UI/UX, aucun impact sur le flow OTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)